### PR TITLE
Allow current temperature to show in steps of 0.1, fixes esphome 2026.3.0 compatibility

### DIFF
--- a/esphome/components/wavin_ahc9000/sensor.py
+++ b/esphome/components/wavin_ahc9000/sensor.py
@@ -13,35 +13,49 @@ from . import WavinAHC9000
 
 CONF_PARENT_ID = "wavin_ahc9000_id"
 CONF_CHANNEL = "channel"
-
-
 CONF_TYPE = "type"
 
-CONFIG_SCHEMA = sensor.sensor_schema().extend(
-    {
-        cv.GenerateID(CONF_PARENT_ID): cv.use_id(WavinAHC9000),
-        cv.Required(CONF_CHANNEL): cv.int_range(min=1, max=16),
-    cv.Required(CONF_TYPE): cv.one_of("battery", "temperature", "comfort_setpoint", "floor_temperature", "floor_min_temperature", "floor_max_temperature", lower=True),
-    }
-)
+def _apply_defaults(config):
+    t = config[CONF_TYPE]
 
+    if t == "battery":
+        config.setdefault("device_class", DEVICE_CLASS_BATTERY)
+        config.setdefault("unit_of_measurement", UNIT_PERCENT)
+        config.setdefault("icon", ICON_BATTERY)
+        config.setdefault("accuracy_decimals", 0)
+    else:
+        config.setdefault("device_class", DEVICE_CLASS_TEMPERATURE)
+        config.setdefault("unit_of_measurement", UNIT_CELSIUS)
+        config.setdefault("accuracy_decimals", 1)
+
+    return config
+
+CONFIG_SCHEMA = cv.All(
+    sensor.sensor_schema().extend(
+        {
+            cv.GenerateID(CONF_PARENT_ID): cv.use_id(WavinAHC9000),
+            cv.Required(CONF_CHANNEL): cv.int_range(min=1, max=16),
+            cv.Required(CONF_TYPE): cv.one_of(
+                "battery",
+                "temperature",
+                "comfort_setpoint",
+                "floor_temperature",
+                "floor_min_temperature",
+                "floor_max_temperature",
+                lower=True,
+            ),
+        }
+    ),
+    _apply_defaults,
+)
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_PARENT_ID])
     sens = await sensor.new_sensor(config)
-    # Apply defaults based on sensor type
+
     if config[CONF_TYPE] == "battery":
-        cg.add(sens.set_device_class(DEVICE_CLASS_BATTERY))
-        cg.add(sens.set_unit_of_measurement(UNIT_PERCENT))
-        cg.add(sens.set_icon(ICON_BATTERY))
-        cg.add(sens.set_accuracy_decimals(0))
         cg.add(hub.add_channel_battery_sensor(config[CONF_CHANNEL], sens))
-    # yaml_ready numeric sensor removed in favor of binary_sensor platform
     else:
-        # temperature & comfort_setpoint share temperature meta
-        cg.add(sens.set_device_class(DEVICE_CLASS_TEMPERATURE))
-        cg.add(sens.set_unit_of_measurement(UNIT_CELSIUS))
-        cg.add(sens.set_accuracy_decimals(1))
         if config[CONF_TYPE] == "comfort_setpoint":
             cg.add(hub.add_channel_comfort_setpoint_sensor(config[CONF_CHANNEL], sens))
         elif config[CONF_TYPE] == "floor_temperature":
@@ -52,4 +66,5 @@ async def to_code(config):
             cg.add(hub.add_channel_floor_max_temperature_sensor(config[CONF_CHANNEL], sens))
         else:
             cg.add(hub.add_channel_temperature_sensor(config[CONF_CHANNEL], sens))
+
     cg.add(hub.add_active_channel(config[CONF_CHANNEL]))

--- a/esphome/components/wavin_ahc9000/wavin_ahc9000.cpp
+++ b/esphome/components/wavin_ahc9000/wavin_ahc9000.cpp
@@ -1209,7 +1209,8 @@ climate::ClimateTraits WavinZoneClimate::traits() {
   }
   t.set_visual_min_temperature(vmin);
   t.set_visual_max_temperature(vmax);
-  t.set_visual_temperature_step(0.5f);
+  t.set_visual_current_temperature_step(0.1);
+  t.set_visual_target_temperature_step(0.5);
   return t;
 }
 void WavinZoneClimate::control(const climate::ClimateCall &call) {

--- a/esphome/components/wavin_ahc9000/wavin_ahc9000.cpp
+++ b/esphome/components/wavin_ahc9000/wavin_ahc9000.cpp
@@ -1194,14 +1194,14 @@ void WavinZoneClimate::dump_config() { LOG_CLIMATE("  ", "Wavin Zone Climate (mi
 climate::ClimateTraits WavinZoneClimate::traits() {
   climate::ClimateTraits t;
   t.set_supported_modes({climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_OFF});
-  t.set_supports_current_temperature(true);
-  t.set_supports_action(true);
+  t.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
+  t.add_feature_flags(climate::CLIMATE_SUPPORTS_ACTION);
   // Default visual bounds
   float vmin = 5.0f;
   float vmax = 35.0f;
   // For comfort climates (using floor temperature), adopt current floor min/max when available
   if (this->single_channel_set_ && this->use_floor_temperature_) {
-    t.set_supports_two_point_target_temperature(true);
+    t.add_feature_flags(climate::CLIMATE_SUPPORTS_TWO_POINT_TARGET_TEMPERATURE);
     float fmin = this->parent_->get_channel_floor_min_temp(this->single_channel_);
     float fmax = this->parent_->get_channel_floor_max_temp(this->single_channel_);
     if (!std::isnan(fmin)) vmin = fmin;


### PR DESCRIPTION
At least on my wavin sensors, the temperature is measured in steps of 0.1 degrees, even if the target temperature is set in steps of 0.5 degrees.

This PR enables to show the current temperature with its full precision.

Also fixes esphome 2026.3.0 compatibility.