### PR TITLE
removing compile errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build/
 
 # Logs
 *.log
+.venv

--- a/esphome/components/wavin_ahc9000/sensor.py
+++ b/esphome/components/wavin_ahc9000/sensor.py
@@ -13,43 +13,52 @@ from . import WavinAHC9000
 
 CONF_PARENT_ID = "wavin_ahc9000_id"
 CONF_CHANNEL = "channel"
-
-
 CONF_TYPE = "type"
 
-CONFIG_SCHEMA = sensor.sensor_schema().extend(
-    {
-        cv.GenerateID(CONF_PARENT_ID): cv.use_id(WavinAHC9000),
-        cv.Required(CONF_CHANNEL): cv.int_range(min=1, max=16),
-    cv.Required(CONF_TYPE): cv.one_of("battery", "temperature", "comfort_setpoint", "floor_temperature", "floor_min_temperature", "floor_max_temperature", lower=True),
-    }
-)
+_COMMON_FIELDS = {
+    cv.GenerateID(CONF_PARENT_ID): cv.use_id(WavinAHC9000),
+    cv.Required(CONF_CHANNEL): cv.int_range(min=1, max=16),
+    cv.Required(CONF_TYPE): cv.one_of(
+        "battery", "temperature", "comfort_setpoint",
+        "floor_temperature", "floor_min_temperature", "floor_max_temperature",
+        lower=True,
+    ),
+}
+
+
+def _validate(config):
+    if config.get(CONF_TYPE) == "battery":
+        base = sensor.sensor_schema(
+            device_class=DEVICE_CLASS_BATTERY,
+            unit_of_measurement=UNIT_PERCENT,
+            icon=ICON_BATTERY,
+            accuracy_decimals=0,
+        )
+    else:
+        base = sensor.sensor_schema(
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+        )
+    return base.extend(_COMMON_FIELDS)(config)
+
+
+CONFIG_SCHEMA = _validate
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_PARENT_ID])
     sens = await sensor.new_sensor(config)
-    # Apply defaults based on sensor type
     if config[CONF_TYPE] == "battery":
-        cg.add(sens.set_device_class(DEVICE_CLASS_BATTERY))
-        cg.add(sens.set_unit_of_measurement(UNIT_PERCENT))
-        cg.add(sens.set_icon(ICON_BATTERY))
-        cg.add(sens.set_accuracy_decimals(0))
         cg.add(hub.add_channel_battery_sensor(config[CONF_CHANNEL], sens))
-    # yaml_ready numeric sensor removed in favor of binary_sensor platform
+    elif config[CONF_TYPE] == "comfort_setpoint":
+        cg.add(hub.add_channel_comfort_setpoint_sensor(config[CONF_CHANNEL], sens))
+    elif config[CONF_TYPE] == "floor_temperature":
+        cg.add(hub.add_channel_floor_temperature_sensor(config[CONF_CHANNEL], sens))
+    elif config[CONF_TYPE] == "floor_min_temperature":
+        cg.add(hub.add_channel_floor_min_temperature_sensor(config[CONF_CHANNEL], sens))
+    elif config[CONF_TYPE] == "floor_max_temperature":
+        cg.add(hub.add_channel_floor_max_temperature_sensor(config[CONF_CHANNEL], sens))
     else:
-        # temperature & comfort_setpoint share temperature meta
-        cg.add(sens.set_device_class(DEVICE_CLASS_TEMPERATURE))
-        cg.add(sens.set_unit_of_measurement(UNIT_CELSIUS))
-        cg.add(sens.set_accuracy_decimals(1))
-        if config[CONF_TYPE] == "comfort_setpoint":
-            cg.add(hub.add_channel_comfort_setpoint_sensor(config[CONF_CHANNEL], sens))
-        elif config[CONF_TYPE] == "floor_temperature":
-            cg.add(hub.add_channel_floor_temperature_sensor(config[CONF_CHANNEL], sens))
-        elif config[CONF_TYPE] == "floor_min_temperature":
-            cg.add(hub.add_channel_floor_min_temperature_sensor(config[CONF_CHANNEL], sens))
-        elif config[CONF_TYPE] == "floor_max_temperature":
-            cg.add(hub.add_channel_floor_max_temperature_sensor(config[CONF_CHANNEL], sens))
-        else:
-            cg.add(hub.add_channel_temperature_sensor(config[CONF_CHANNEL], sens))
+        cg.add(hub.add_channel_temperature_sensor(config[CONF_CHANNEL], sens))
     cg.add(hub.add_active_channel(config[CONF_CHANNEL]))


### PR DESCRIPTION
This pull request refactors the configuration schema logic for the `wavin_ahc9000` sensor component to improve maintainability and reduce redundancy. The most significant changes involve centralizing default sensor configuration based on type and simplifying the schema definition.

**Schema and configuration improvements:**

* Introduced a `_COMMON_FIELDS` dictionary to consolidate common configuration fields, reducing repetition in the schema.
* Added a `_validate` function to automatically apply default sensor properties (such as `device_class`, `unit_of_measurement`, `icon`, and `accuracy_decimals`) based on the sensor `type`, and set `CONFIG_SCHEMA` to use this validator.

**Code simplification:**

* Removed redundant code in `to_code` by moving the application of default sensor properties into the schema validation step, resulting in a cleaner and more maintainable function.


**This is needed when upgrading to version 2026.3.0**