### PR TITLE
Fixing sensor.py compile errors with ESPHome 2026.3.3

### DIFF
--- a/esphome/components/wavin_ahc9000/sensor.py
+++ b/esphome/components/wavin_ahc9000/sensor.py
@@ -73,7 +73,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required(CONF_CHANNEL): cv.int_range(min=1, max=16),
         cv.Required(CONF_TYPE): cv.one_of(*_SENSOR_DEFAULTS.keys(), lower=True),
     }
-).extend(sensor.SENSOR_SCHEMA)
+).extend(sensor.sensor_schema())
 
 CONFIG_SCHEMA = cv.All(CONFIG_SCHEMA, _sensor_schema)
 

--- a/esphome/components/wavin_ahc9000/sensor.py
+++ b/esphome/components/wavin_ahc9000/sensor.py
@@ -7,49 +7,92 @@ from esphome.const import (
     ICON_BATTERY,
     DEVICE_CLASS_TEMPERATURE,
     UNIT_CELSIUS,
+    STATE_CLASS_MEASUREMENT,
 )
 
 from . import WavinAHC9000
 
 CONF_PARENT_ID = "wavin_ahc9000_id"
 CONF_CHANNEL = "channel"
-
-
 CONF_TYPE = "type"
 
-CONFIG_SCHEMA = sensor.sensor_schema().extend(
+# Per-type schema defaults
+_SENSOR_DEFAULTS = {
+    "battery": sensor.sensor_schema(
+        unit_of_measurement=UNIT_PERCENT,
+        icon=ICON_BATTERY,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_BATTERY,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    "temperature": sensor.sensor_schema(
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    "comfort_setpoint": sensor.sensor_schema(
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    "floor_temperature": sensor.sensor_schema(
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    "floor_min_temperature": sensor.sensor_schema(
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    "floor_max_temperature": sensor.sensor_schema(
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+}
+
+def _sensor_schema(config):
+    """Validate and apply per-type schema defaults."""
+    sensor_type = config[CONF_TYPE]
+    schema = _SENSOR_DEFAULTS[sensor_type].extend({
+        cv.GenerateID(CONF_PARENT_ID): cv.use_id(WavinAHC9000),
+        cv.Required(CONF_CHANNEL): cv.int_range(min=1, max=16),
+        cv.Required(CONF_TYPE): cv.one_of(*_SENSOR_DEFAULTS.keys(), lower=True),
+    })
+    return schema(config)
+
+CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_PARENT_ID): cv.use_id(WavinAHC9000),
         cv.Required(CONF_CHANNEL): cv.int_range(min=1, max=16),
-    cv.Required(CONF_TYPE): cv.one_of("battery", "temperature", "comfort_setpoint", "floor_temperature", "floor_min_temperature", "floor_max_temperature", lower=True),
+        cv.Required(CONF_TYPE): cv.one_of(*_SENSOR_DEFAULTS.keys(), lower=True),
     }
-)
+).extend(sensor.SENSOR_SCHEMA)
+
+CONFIG_SCHEMA = cv.All(CONFIG_SCHEMA, _sensor_schema)
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_PARENT_ID])
     sens = await sensor.new_sensor(config)
-    # Apply defaults based on sensor type
+
     if config[CONF_TYPE] == "battery":
-        cg.add(sens.set_device_class(DEVICE_CLASS_BATTERY))
-        cg.add(sens.set_unit_of_measurement(UNIT_PERCENT))
-        cg.add(sens.set_icon(ICON_BATTERY))
-        cg.add(sens.set_accuracy_decimals(0))
         cg.add(hub.add_channel_battery_sensor(config[CONF_CHANNEL], sens))
-    # yaml_ready numeric sensor removed in favor of binary_sensor platform
+    elif config[CONF_TYPE] == "comfort_setpoint":
+        cg.add(hub.add_channel_comfort_setpoint_sensor(config[CONF_CHANNEL], sens))
+    elif config[CONF_TYPE] == "floor_temperature":
+        cg.add(hub.add_channel_floor_temperature_sensor(config[CONF_CHANNEL], sens))
+    elif config[CONF_TYPE] == "floor_min_temperature":
+        cg.add(hub.add_channel_floor_min_temperature_sensor(config[CONF_CHANNEL], sens))
+    elif config[CONF_TYPE] == "floor_max_temperature":
+        cg.add(hub.add_channel_floor_max_temperature_sensor(config[CONF_CHANNEL], sens))
     else:
-        # temperature & comfort_setpoint share temperature meta
-        cg.add(sens.set_device_class(DEVICE_CLASS_TEMPERATURE))
-        cg.add(sens.set_unit_of_measurement(UNIT_CELSIUS))
-        cg.add(sens.set_accuracy_decimals(1))
-        if config[CONF_TYPE] == "comfort_setpoint":
-            cg.add(hub.add_channel_comfort_setpoint_sensor(config[CONF_CHANNEL], sens))
-        elif config[CONF_TYPE] == "floor_temperature":
-            cg.add(hub.add_channel_floor_temperature_sensor(config[CONF_CHANNEL], sens))
-        elif config[CONF_TYPE] == "floor_min_temperature":
-            cg.add(hub.add_channel_floor_min_temperature_sensor(config[CONF_CHANNEL], sens))
-        elif config[CONF_TYPE] == "floor_max_temperature":
-            cg.add(hub.add_channel_floor_max_temperature_sensor(config[CONF_CHANNEL], sens))
-        else:
-            cg.add(hub.add_channel_temperature_sensor(config[CONF_CHANNEL], sens))
+        cg.add(hub.add_channel_temperature_sensor(config[CONF_CHANNEL], sens))
+
     cg.add(hub.add_active_channel(config[CONF_CHANNEL]))

--- a/esphome/components/wavin_ahc9000/sensor.py
+++ b/esphome/components/wavin_ahc9000/sensor.py
@@ -2,6 +2,11 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor
 from esphome.const import (
+    CONF_UNIT_OF_MEASUREMENT,
+    CONF_ACCURACY_DECIMALS,
+    CONF_DEVICE_CLASS,
+    CONF_STATE_CLASS,
+    CONF_ICON,
     UNIT_PERCENT,
     DEVICE_CLASS_BATTERY,
     ICON_BATTERY,
@@ -16,66 +21,68 @@ CONF_PARENT_ID = "wavin_ahc9000_id"
 CONF_CHANNEL = "channel"
 CONF_TYPE = "type"
 
-# Per-type schema defaults
+# Per-type sensor field defaults (plain dicts, not schemas)
 _SENSOR_DEFAULTS = {
-    "battery": sensor.sensor_schema(
-        unit_of_measurement=UNIT_PERCENT,
-        icon=ICON_BATTERY,
-        accuracy_decimals=0,
-        device_class=DEVICE_CLASS_BATTERY,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    "temperature": sensor.sensor_schema(
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    "comfort_setpoint": sensor.sensor_schema(
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    "floor_temperature": sensor.sensor_schema(
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    "floor_min_temperature": sensor.sensor_schema(
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
-    "floor_max_temperature": sensor.sensor_schema(
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_TEMPERATURE,
-        state_class=STATE_CLASS_MEASUREMENT,
-    ),
+    "battery": {
+        CONF_UNIT_OF_MEASUREMENT: UNIT_PERCENT,
+        CONF_ICON: ICON_BATTERY,
+        CONF_ACCURACY_DECIMALS: 0,
+        CONF_DEVICE_CLASS: DEVICE_CLASS_BATTERY,
+        CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT,
+    },
+    "temperature": {
+        CONF_UNIT_OF_MEASUREMENT: UNIT_CELSIUS,
+        CONF_ACCURACY_DECIMALS: 1,
+        CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
+        CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT,
+    },
+    "comfort_setpoint": {
+        CONF_UNIT_OF_MEASUREMENT: UNIT_CELSIUS,
+        CONF_ACCURACY_DECIMALS: 1,
+        CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
+        CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT,
+    },
+    "floor_temperature": {
+        CONF_UNIT_OF_MEASUREMENT: UNIT_CELSIUS,
+        CONF_ACCURACY_DECIMALS: 1,
+        CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
+        CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT,
+    },
+    "floor_min_temperature": {
+        CONF_UNIT_OF_MEASUREMENT: UNIT_CELSIUS,
+        CONF_ACCURACY_DECIMALS: 1,
+        CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
+        CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT,
+    },
+    "floor_max_temperature": {
+        CONF_UNIT_OF_MEASUREMENT: UNIT_CELSIUS,
+        CONF_ACCURACY_DECIMALS: 1,
+        CONF_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
+        CONF_STATE_CLASS: STATE_CLASS_MEASUREMENT,
+    },
 }
 
-def _sensor_schema(config):
-    """Validate and apply per-type schema defaults."""
-    sensor_type = config[CONF_TYPE]
-    schema = _SENSOR_DEFAULTS[sensor_type].extend({
-        cv.GenerateID(CONF_PARENT_ID): cv.use_id(WavinAHC9000),
-        cv.Required(CONF_CHANNEL): cv.int_range(min=1, max=16),
-        cv.Required(CONF_TYPE): cv.one_of(*_SENSOR_DEFAULTS.keys(), lower=True),
-    })
-    return schema(config)
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(CONF_PARENT_ID): cv.use_id(WavinAHC9000),
-        cv.Required(CONF_CHANNEL): cv.int_range(min=1, max=16),
-        cv.Required(CONF_TYPE): cv.one_of(*_SENSOR_DEFAULTS.keys(), lower=True),
-    }
-).extend(sensor.sensor_schema())
+def _apply_sensor_defaults(config):
+    """Fill in per-type defaults for sensor fields not explicitly set."""
+    defaults = _SENSOR_DEFAULTS[config[CONF_TYPE]]
+    config = dict(config)
+    for key, value in defaults.items():
+        if key not in config:
+            config[key] = value
+    return config
 
-CONFIG_SCHEMA = cv.All(CONFIG_SCHEMA, _sensor_schema)
+
+CONFIG_SCHEMA = cv.All(
+    sensor.sensor_schema().extend(
+        {
+            cv.GenerateID(CONF_PARENT_ID): cv.use_id(WavinAHC9000),
+            cv.Required(CONF_CHANNEL): cv.int_range(min=1, max=16),
+            cv.Required(CONF_TYPE): cv.one_of(*_SENSOR_DEFAULTS.keys(), lower=True),
+        }
+    ),
+    _apply_sensor_defaults,
+)
 
 
 async def to_code(config):

--- a/esphome/components/wavin_ahc9000/sensor.py
+++ b/esphome/components/wavin_ahc9000/sensor.py
@@ -21,7 +21,8 @@ CONF_PARENT_ID = "wavin_ahc9000_id"
 CONF_CHANNEL = "channel"
 CONF_TYPE = "type"
 
-# Per-type sensor field defaults (plain dicts, not schemas)
+# Per-type sensor field defaults (plain dicts, strings only — will be
+# validated and converted to proper ESPHome types by sensor.sensor_schema())
 _SENSOR_DEFAULTS = {
     "battery": {
         CONF_UNIT_OF_MEASUREMENT: UNIT_PERCENT,
@@ -62,9 +63,20 @@ _SENSOR_DEFAULTS = {
     },
 }
 
+# Extra wavin-specific fields shared across both schema passes
+_WAVIN_FIELDS = {
+    cv.GenerateID(CONF_PARENT_ID): cv.use_id(WavinAHC9000),
+    cv.Required(CONF_CHANNEL): cv.int_range(min=1, max=16),
+    cv.Required(CONF_TYPE): cv.one_of(*_SENSOR_DEFAULTS.keys(), lower=True),
+}
+
 
 def _apply_sensor_defaults(config):
-    """Fill in per-type defaults for sensor fields not explicitly set."""
+    """Fill in per-type defaults BEFORE sensor.sensor_schema() validates them.
+
+    This ensures string values like STATE_CLASS_MEASUREMENT are converted to
+    proper ESPHome enum types by the schema validator that follows.
+    """
     defaults = _SENSOR_DEFAULTS[config[CONF_TYPE]]
     config = dict(config)
     for key, value in defaults.items():
@@ -74,14 +86,14 @@ def _apply_sensor_defaults(config):
 
 
 CONFIG_SCHEMA = cv.All(
-    sensor.sensor_schema().extend(
-        {
-            cv.GenerateID(CONF_PARENT_ID): cv.use_id(WavinAHC9000),
-            cv.Required(CONF_CHANNEL): cv.int_range(min=1, max=16),
-            cv.Required(CONF_TYPE): cv.one_of(*_SENSOR_DEFAULTS.keys(), lower=True),
-        }
-    ),
+    # Pass 1: validate wavin-specific fields; allow all other keys through
+    # so that sensor fields (name, id, …) are not rejected.
+    cv.Schema(_WAVIN_FIELDS, extra=cv.ALLOW_EXTRA),
+    # Fill in per-type defaults while values are still plain strings.
     _apply_sensor_defaults,
+    # Pass 2: full sensor schema validation — converts strings to typed
+    # ESPHome values (e.g. "measurement" → StateClass enum) exactly once.
+    sensor.sensor_schema().extend(_WAVIN_FIELDS),
 )
 
 


### PR DESCRIPTION
This PR rewites sensor.py to use the new `sensor.sensor_schema()` definition that is required by ESPHome 2026.3.3 and removes compile errors.

Can be tested by changing the reference to the source from `source: github://heinekmadsen/esphome_wavinahc9000v3` to `source: github://briis/esphome_wavinahc9000v3`